### PR TITLE
Add plot.init and grammar fixes to README.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -11,11 +11,11 @@ This plugins supports both IOS 6 or newer, and Android 2.3 or newer.
 
 ### Phonegap Build ###
 
-You have to add the following line to `config.xml` to add our plugin:
+Add the following line to `config.xml` to add our plugin:
 
 ```<gap:plugin name="cordova-plotprojects" source="npm" version="1.12.0" />```
 
-### Installation other environments ###
+### Installation for Other Builds###
 
 You can add the plugin to an existing project by executing the following command:
 
@@ -23,7 +23,7 @@ Phonegap: ```phonegap plugin add cordova-plotprojects```
  
 Cordova: ```cordova plugin add cordova-plotprojects```
 
-### Integration and configuration ###
+### Integration and Configuration ###
 
 You can find the integration guide at our website: [http://www.plotprojects.com/phonegap-integration/](http://www.plotprojects.com/phonegap-integration/)
 
@@ -43,6 +43,10 @@ Information about these settings can be found in our extensive documentation, in
 ```
 
 ### Function reference ###
+
+_plot.init()_
+
+Initializes Plot.
 
 _plot.enable()_
 

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@ Install Plot into your PhoneGap/Cordova app quickly
 
 Get location based notifications in your PhoneGap app! Now also supports iBeacons for iOS out of the box and for Android after also integrating our Android iBeacon plugin found here: [https://github.com/Plotprojects/plot-phonegap-plugin-androidibeacons](https://github.com/Plotprojects/plot-phonegap-plugin-androidibeacons)
 
-### Supported platforms ###
+### Supported Platforms ###
 
 This plugins requires PhoneGap 3.0.0 or higher.
 This plugins supports both IOS 6 or newer, and Android 2.3 or newer.
@@ -42,7 +42,7 @@ Information about these settings can be found in our extensive documentation, in
 }
 ```
 
-### Function reference ###
+### Function Reference ###
 
 _plot.init()_
 
@@ -58,7 +58,7 @@ Disables Plot.
 
 _plot.isEnabled()_
 
-Returns whether plot is enabled (read-only).
+Returns whether Plot is enabled (read-only).
 
 _plot.setCooldownPeriod(cooldownSeconds)_
 
@@ -72,7 +72,7 @@ _plot.mailDebugLog()_
 
 Sends the collected debug log via mail. It will open your mail application to send the mail.
 
-### Function reference - Segmentation ###
+### Function Reference - Segmentation ###
 
 More information about this feature can be found on our documentation page: [http://www.plotprojects.com/documentation#phonegap_segmentation](http://www.plotprojects.com/documentation#phonegap_segmentation)
 
@@ -122,7 +122,7 @@ plot.notificationHandler = function(notification, data) {
 }
 ```
 
-### Retrieving loaded notifications and geotriggers ###
+### Retrieving Loaded Notifications and Geotriggers ###
 
 You can retrieve the loaded notifications and geotriggers using the `loadedNotifications(callback)` and the `loadedGeotriggers(callback)` method.
 
@@ -136,7 +136,7 @@ plot.loadedGeotriggers(function(geotriggers) {
 });
 ```
 
-### More information ###
+### More Information ###
 Website: [http://www.plotprojects.com/](http://www.plotprojects.com/)
 
 Documentation: [http://www.plotprojects.com/documentation](http://www.plotprojects.com/documentation)


### PR DESCRIPTION
#### Additional Documentation ####
Adds the missing `plot.init` function to the "Function reference" section. Re: #8.

#### Grammar Fixes ####
- Made section titles capitalized like "Phonegap Build"

    ![screen shot 2016-01-08 at 4 12 05 pm](https://cloud.githubusercontent.com/assets/8163408/12212764/bbdd50e2-b622-11e5-9565-7e00cda6429b.png)

- Improved "other environments" title to "Other Builds"
    
    ![screen shot 2016-01-08 at 4 14 20 pm](https://cloud.githubusercontent.com/assets/8163408/12212779/e4315340-b622-11e5-88c8-ea292001d659.png)

- Capitalized "Plot" in description for `plot.isEnabled()`

    ![screen shot 2016-01-08 at 4 12 16 pm](https://cloud.githubusercontent.com/assets/8163408/12212772/ccf995ca-b622-11e5-938c-1db65d80b04d.png)